### PR TITLE
[autonity-network] Add http basic auth for observers

### DIFF
--- a/stable/autonity-network/CHANGELOG.md
+++ b/stable/autonity-network/CHANGELOG.md
@@ -6,9 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2] - 2019-08-20
+### Added
+- http basic auth support for autonity RPC (for observers)
+- autonity version update to v0.1.5 
+
 ## [0.3.1] - 2019-08-19
 ### Added
-- http basic auth support for autonity RPC
+- http basic auth support for autonity RPC (for validators only)
 
 ## [0.3.0] - 2019-08-13
 ### Changed

--- a/stable/autonity-network/Chart.yaml
+++ b/stable/autonity-network/Chart.yaml
@@ -1,5 +1,5 @@
 name: autonity-network
-version: 0.3.1
+version: 0.3.2
 kubeVersion: ">=1.10.0-0"
 description: Chart for deploy full Autonity network
 keywords:
@@ -11,4 +11,4 @@ sources:
 maintainers:
 - name: eastata
   email: aleksandr.poliakov@clearmatics.com
-appVersion: v0.2.0-alpha
+appVersion: v0.1.5

--- a/stable/autonity-network/templates/deployments_observers.yaml
+++ b/stable/autonity-network/templates/deployments_observers.yaml
@@ -1,10 +1,12 @@
 {{- $imageAutonity := .Values.imageAutonity -}}
 {{- $imageAutonity_init := .Values.imageAutonity_init -}}
 {{- $imagePrometheusExporter := .Values.image_prometheus_exporter -}}
+{{- $imageNginx := .Values.image_nginx -}}
 {{- $namespace := .Release.Namespace -}}
 
 {{- $ethstatsEnabled :=  .Values.global.ethstats.enabled -}}
 {{- $prometheusEnabled :=  .Values.global.prometheus.enabled -}}
+{{- $rpcHttpBasicAuthEnabled :=  .Values.rpc_http_basic_auth_enabled -}}
 
 {{ range $i, $e := until (atoi (printf "%d" (int64 .Values.observers))) }}
 ---
@@ -39,8 +41,6 @@ spec:
       - name: autonity
         image: {{ $imageAutonity.repository }}:{{ $imageAutonity.tag }}
         ports:
-        - containerPort: 8545
-          name: rpc
         - containerPort: 30303
           name: p2p
         args:
@@ -59,8 +59,6 @@ spec:
           - "--rpc"
           - "--rpcapi"
           - "eth,web3,net,txpool,debug"
-          - "--rpcaddr"
-          - "0.0.0.0"
           - "--rpcvhosts"
           - "*"
           - "--ws"
@@ -102,6 +100,20 @@ spec:
         - name: blockchain
           mountPath: /autonity/blockchain
 {{ end }}
+      - name: nginx
+        image: {{ $imageNginx.repository }}:{{ $imageNginx.tag }}
+        ports:
+        - containerPort: 8080
+          name: https-rpc
+        volumeMounts:
+        - name: nginx-proxy-config
+          mountPath: /etc/nginx/nginx.conf
+          subPath: nginx.conf
+{{ if $rpcHttpBasicAuthEnabled }}
+        - name: nginx-proxy-config
+          mountPath: /etc/nginx/htpasswd
+          subPath: htpasswd
+{{ end }}
       volumes:
         - name: blockchain
           emptyDir: {}
@@ -121,4 +133,7 @@ spec:
             items:
               - key: {{ $i }}.private_key
                 path: private_key
+        - name: nginx-proxy-config
+          configMap:
+            name: nginx-conf
 {{- end}}

--- a/stable/autonity-network/templates/services_observers.yaml
+++ b/stable/autonity-network/templates/services_observers.yaml
@@ -17,9 +17,9 @@ spec:
   type: ClusterIP
   ports:
     - protocol: TCP
-      name: rpc
+      name: https-rpc
       port: 8545
-      targetPort: 8545
+      targetPort: 8080
     - protocol: TCP
       name: p2p
       port: 30303

--- a/stable/autonity-network/values.yaml
+++ b/stable/autonity-network/values.yaml
@@ -2,11 +2,11 @@
 
 imageAutonity:
   repository: clearmatics/autonity
-  tag: v0.2.0-alpha
+  tag: v0.1.5
 
 imageAutonity_init:
   repository: clearmatics/autonity-init
-  tag: v0.0.6
+  tag: v0.0.7
 
 image_ibft_keys_generator:
   repository: clearmatics/ibft-keys-generator


### PR DESCRIPTION
### Changelog:
### Added
- http basic auth support for autonity RPC (for observers)
- autonity version update to v0.1.5 

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](CONTRIBUTING.md)?
* [x] Is the `branch` name the same as Chart name that you will release?
* [x] Is your changes touch only one chart?
* [x] Is the version of chart incremented in `Chart.yaml`?

Issue https://github.com/clearmatics/charts/issues/6
