### PR TITLE
[autonity-network] Release 1.0.0

### DIFF
--- a/stable/autonity-network/CHANGELOG.md
+++ b/stable/autonity-network/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - 2019-09-16
+### Updated
+- Switch to native prometheus metrics. Option `global.prometheus.enabled` is deprecated
+    - Metrics port changed to `6060`
+    - deleted sidecar `prometheus-exporter`
+    - metrics enabled by default
 ## [0.3.7] - 2019-09-16
 ### Updated
 - Up docker images:

--- a/stable/autonity-network/Chart.yaml
+++ b/stable/autonity-network/Chart.yaml
@@ -1,5 +1,5 @@
 name: autonity-network
-version: 0.3.7
+version: 1.0.0
 kubeVersion: ">=1.10.0-0"
 description: Chart for deploy full Autonity network
 keywords:

--- a/stable/autonity-network/templates/deployments_observers.yaml
+++ b/stable/autonity-network/templates/deployments_observers.yaml
@@ -72,6 +72,7 @@ spec:
           - "--wsorigins"
           - "*"
           - "--metrics"
+          - "--pprof"
           - "--debug"
           - "--verbosity"
           - "4"
@@ -92,17 +93,6 @@ spec:
           mountPath: /autonity/keys
         - name: sec-peers
           mountPath: /autonity/sec-peers
-{{ if $prometheusEnabled }}
-      - name: prometheus-exporter
-        image: {{ $imagePrometheusExporter.repository }}:{{ $imagePrometheusExporter.tag }}
-        ports:
-        - containerPort: 9200
-          name: metrics
-        command: ['geth_exporter', '-ipc', '/autonity/blockchain/autonity.ipc']
-        volumeMounts:
-        - name: blockchain
-          mountPath: /autonity/blockchain
-{{ end }}
       - name: nginx
         image: {{ $imageNginx.repository }}:{{ $imageNginx.tag }}
         ports:

--- a/stable/autonity-network/templates/deployments_observers.yaml
+++ b/stable/autonity-network/templates/deployments_observers.yaml
@@ -1,6 +1,5 @@
 {{- $imageAutonity := .Values.imageAutonity -}}
 {{- $imageAutonity_init := .Values.imageAutonity_init -}}
-{{- $imagePrometheusExporter := .Values.image_prometheus_exporter -}}
 {{- $imageNginx := .Values.image_nginx -}}
 {{- $namespace := .Release.Namespace -}}
 {{- $releasename := .Release.Name -}}

--- a/stable/autonity-network/templates/deployments_observers.yaml
+++ b/stable/autonity-network/templates/deployments_observers.yaml
@@ -5,7 +5,6 @@
 {{- $releasename := .Release.Name -}}
 
 {{- $ethstatsEnabled :=  .Values.global.ethstats.enabled -}}
-{{- $prometheusEnabled :=  .Values.global.prometheus.enabled -}}
 {{- $rpcHttpBasicAuthEnabled :=  .Values.rpc_http_basic_auth_enabled -}}
 {{- $rpcHttpsEnabled :=  .Values.rpc_https_enabled -}}
 

--- a/stable/autonity-network/templates/deployments_observers.yaml
+++ b/stable/autonity-network/templates/deployments_observers.yaml
@@ -71,6 +71,8 @@ spec:
           - "*"
           - "--metrics"
           - "--pprof"
+          - "--pprofaddr"
+          - "0.0.0.0"
           - "--debug"
           - "--verbosity"
           - "4"

--- a/stable/autonity-network/templates/deployments_validators.yaml
+++ b/stable/autonity-network/templates/deployments_validators.yaml
@@ -74,6 +74,7 @@ spec:
           - "--wsorigins"
           - "*"
           - "--metrics"
+          - "--pprof"
           - "--mine"
           - "--minerthreads"
           - "1"
@@ -97,17 +98,6 @@ spec:
           mountPath: /autonity/keys
         - name: sec-peers
           mountPath: /autonity/sec-peers
-{{ if $prometheusEnabled }}
-      - name: prometheus-exporter
-        image: {{ $imagePrometheusExporter.repository }}:{{ $imagePrometheusExporter.tag }}
-        ports:
-        - containerPort: 9200
-          name: metrics
-        command: ['geth_exporter', '-ipc', '/autonity/blockchain/autonity.ipc']
-        volumeMounts:
-        - name: blockchain
-          mountPath: /autonity/blockchain
-{{ end }}
       - name: nginx
         image: {{ $imageNginx.repository }}:{{ $imageNginx.tag }}
         ports:

--- a/stable/autonity-network/templates/deployments_validators.yaml
+++ b/stable/autonity-network/templates/deployments_validators.yaml
@@ -73,6 +73,8 @@ spec:
           - "*"
           - "--metrics"
           - "--pprof"
+          - "--pprofaddr"
+          - "0.0.0.0"
           - "--mine"
           - "--minerthreads"
           - "1"

--- a/stable/autonity-network/templates/deployments_validators.yaml
+++ b/stable/autonity-network/templates/deployments_validators.yaml
@@ -1,6 +1,5 @@
 {{- $imageAutonity := .Values.imageAutonity -}}
 {{- $imageAutonity_init := .Values.imageAutonity_init -}}
-{{- $imagePrometheusExporter := .Values.image_prometheus_exporter -}}
 {{- $imageNginx := .Values.image_nginx -}}
 {{- $namespace := .Release.Namespace -}}
 {{- $releasename := .Release.Name -}}

--- a/stable/autonity-network/templates/deployments_validators.yaml
+++ b/stable/autonity-network/templates/deployments_validators.yaml
@@ -5,7 +5,6 @@
 {{- $releasename := .Release.Name -}}
 
 {{- $ethstatsEnabled :=  .Values.global.ethstats.enabled -}}
-{{- $prometheusEnabled :=  .Values.global.prometheus.enabled -}}
 {{- $rpcHttpBasicAuthEnabled :=  .Values.rpc_http_basic_auth_enabled -}}
 {{- $rpcHttpsEnabled :=  .Values.rpc_https_enabled -}}
 {{- $awsPersistentStorageEnabled :=  .Values.aws_persistent_storage_enabled -}}

--- a/stable/autonity-network/templates/services_observers.yaml
+++ b/stable/autonity-network/templates/services_observers.yaml
@@ -1,5 +1,4 @@
 {{- $namespace := .Release.Namespace -}}
-{{- $prometheusEnabled :=  .Values.global.prometheus.enabled -}}
 
 {{ range $i, $e := until (atoi (printf "%d" (int64 .Values.observers))) }}
 ---

--- a/stable/autonity-network/templates/services_observers.yaml
+++ b/stable/autonity-network/templates/services_observers.yaml
@@ -9,6 +9,7 @@ metadata:
   namespace: {{ $namespace }}
   annotations:
     prometheus.io/port: "6060"
+    prometheus.io/path: "/debug/metrics/prometheus"
     prometheus.io/scrape: "true"
 spec:
   type: ClusterIP

--- a/stable/autonity-network/templates/services_observers.yaml
+++ b/stable/autonity-network/templates/services_observers.yaml
@@ -8,11 +8,9 @@ kind: Service
 metadata:
   name: observer-{{ $i }}
   namespace: {{ $namespace }}
-{{ if $prometheusEnabled }}
   annotations:
-    prometheus.io/port: "9200"
+    prometheus.io/port: "6060"
     prometheus.io/scrape: "true"
-{{ end }}
 spec:
   type: ClusterIP
   ports:
@@ -28,12 +26,10 @@ spec:
       name: p2p
       port: 30303
       targetPort:  30303
-{{ if $prometheusEnabled }}
     - protocol: TCP
       name: metrics
-      port: 9200
-      targetPort: 9200
-{{ end }}
+      port: 6060
+      targetPort: 6060
   selector:
     app: observer-{{ $i }}
 {{- end}}

--- a/stable/autonity-network/templates/services_validators.yaml
+++ b/stable/autonity-network/templates/services_validators.yaml
@@ -1,5 +1,4 @@
 {{- $namespace := .Release.Namespace -}}
-{{- $prometheusEnabled :=  .Values.global.prometheus.enabled -}}
 
 {{ range $i, $e := until (atoi (printf "%d" (int64 .Values.validators))) }}
 ---

--- a/stable/autonity-network/templates/services_validators.yaml
+++ b/stable/autonity-network/templates/services_validators.yaml
@@ -9,6 +9,7 @@ metadata:
   namespace: {{ $namespace }}
   annotations:
     prometheus.io/port: "6060"
+    prometheus.io/path: "/debug/metrics/prometheus"
     prometheus.io/scrape: "true"
 spec:
   type: ClusterIP

--- a/stable/autonity-network/templates/services_validators.yaml
+++ b/stable/autonity-network/templates/services_validators.yaml
@@ -8,11 +8,9 @@ kind: Service
 metadata:
   name: validator-{{ $i }}
   namespace: {{ $namespace }}
-{{ if $prometheusEnabled }}
   annotations:
-    prometheus.io/port: "9200"
+    prometheus.io/port: "6060"
     prometheus.io/scrape: "true"
-{{ end }}
 spec:
   type: ClusterIP
   ports:
@@ -28,12 +26,10 @@ spec:
       name: p2p
       port: 30303
       targetPort:  30303
-{{ if $prometheusEnabled }}
     - protocol: TCP
       name: metrics
-      port: 9200
-      targetPort: 9200
-{{ end }}
+      port: 6060
+      targetPort: 6060
   selector:
     app: validator-{{ $i }}
 {{- end}}

--- a/stable/autonity-network/values.yaml
+++ b/stable/autonity-network/values.yaml
@@ -16,10 +16,6 @@ image_ibft_genesis_configurator:
   repository: clearmatics/ibft-genesis-configurator
   tag: v0.0.4
 
-image_prometheus_exporter:
-  repository: statusteam/geth_exporter
-  tag: latest
-
 image_nginx:
   repository: nginx
   tag: 1.17-alpine
@@ -49,8 +45,6 @@ files_dir: "files"
 
 global:
   ethstats:
-    enabled: false
-  prometheus:
     enabled: false
   telepresence:
     enabled: false


### PR DESCRIPTION
### Changelog:
### Updated
- Switch to native prometheus metrics. Option `global.prometheus.enabled` is deprecated
    - Metrics port changed to `6060`
    - deleted sidecar `prometheus-exporter`
    - metrics enabled by default

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](CONTRIBUTING.md)?
* [x] Is the `branch` name the same as Chart name that you will release?
* [x] Is your changes touch only one chart?
* [x] Is the version of chart incremented in `Chart.yaml`?

Issue #62 