### PR TITLE
[autonity-network] change helm hook to before-hook-creation

### DIFF
--- a/stable/autonity-network/CHANGELOG.md
+++ b/stable/autonity-network/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [1.5.4] - 2019-10-23
+### Updated
+- helm hook for init_ibft_genesis_configurator from `hook-succeeded` to `before-hook-creation`
+
 ## [1.5.3] - 2019-10-23
 ### Added 
 - `tendermint` to API

--- a/stable/autonity-network/Chart.yaml
+++ b/stable/autonity-network/Chart.yaml
@@ -1,5 +1,5 @@
 name: autonity-network
-version: 1.5.3
+version: 1.5.4
 kubeVersion: ">=1.10.0-0"
 description: Chart for deploy full Autonity network
 keywords:

--- a/stable/autonity-network/README.md
+++ b/stable/autonity-network/README.md
@@ -32,7 +32,7 @@ Autonity is a generalization of the Ethereum protocol based on a fork of go-ethe
 ## Prerequisites
 
 * Kubernetes 1.10
-* Helm 2.13
+* Helm 2.15
 
 ## Kubernetes objects
 This chart is comprised of 4 components:

--- a/stable/autonity-network/templates/init_job02_ibft_genesis_configurator.yaml
+++ b/stable/autonity-network/templates/init_job02_ibft_genesis_configurator.yaml
@@ -20,7 +20,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install
     "helm.sh/hook-weight": "2"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   template:
     metadata:


### PR DESCRIPTION
### Changelog:
- helm hook for init_ibft_genesis_configurator from `hook-succeeded` to `before-hook-creation`

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](CONTRIBUTING.md)?
* [x] Is the `branch` name the same as Chart name that you will release?
* [x] Is your changes touch only one chart?
* [x] Is the version of chart incremented in `Chart.yaml`?

Issue #113